### PR TITLE
Added dataclass example to MenuConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,41 @@ class MenuConfig(NamedTuple):
 
 def create_menu(config: MenuConfig):
     title, body, button_text, cancellable = config
+    # ...
+
+
+create_menu(
+    MenuConfig(
+        title="My delicious menu",
+        body="A description of the various items on the menu",
+        button_text="Order now!"
+    )
+)
+```
+
+**Even fancier**
+```python
+from dataclasses import astuple, dataclass
+
+
+@dataclass
+class MenuConfig:
+    """A configuration for the Menu.
+
+    Attributes:
+        title: The title of the Menu.
+        body: The body of the Menu.
+        button_text: The text for the button label.
+        cancellable: Can it be cancelled?
+    """
+    title: str
+    body: str
+    button_text: str
+    cancellable: bool = False
+
+def create_menu(config: MenuConfig):
+    title, body, button_text, cancellable = astuple(config)
+    # ...
 
 
 create_menu(


### PR DESCRIPTION
I leveraged the `astuple` function from `dataclasses` in order to maintain the same tuple unpacking semantics. This may not be the most canonical way to accomplish the goal using a dataclass, so feedback welcome!

I'm a big fan of this resource and of 3.7 dataclasses. Thanks for all you guys do!