### PR TITLE
Add a blank link before code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Targets Python3.7+
 ### Use meaningful and pronounceable variable names
 
 **Bad:**
+
 ```python
 import datetime
 
@@ -43,6 +44,7 @@ ymdstr = datetime.date.today().strftime("%y-%m-%d")
 ```
 
 **Good**:
+
 ```python
 import datetime
 
@@ -55,6 +57,7 @@ current_date: str = datetime.date.today().strftime("%y-%m-%d")
 
 **Bad:**
 Here we use three different names for the same underlying entity:
+
 ```python
 def get_user_info(): pass
 def get_client_data(): pass
@@ -63,6 +66,7 @@ def get_customer_record(): pass
 
 **Good**:
 If the entity is the same, you should be consistent in referring to it in your functions:
+
 ```python
 def get_user_info(): pass
 def get_user_data(): pass
@@ -101,6 +105,7 @@ understanding our program, we hurt our readers.
 Make your names searchable.
 
 **Bad:**
+
 ```python
 import time
 
@@ -110,6 +115,7 @@ time.sleep(86400)
 ```
 
 **Good**:
+
 ```python
 import time
 
@@ -122,6 +128,7 @@ time.sleep(SECONDS_IN_A_DAY)
 
 ### Use explanatory variables
 **Bad:**
+
 ```python
 import re
 
@@ -154,6 +161,7 @@ if matches:
 **Good**:
 
 Decrease dependence on regex by naming subpatterns.
+
 ```python
 import re
 
@@ -172,6 +180,7 @@ Don’t force the reader of your code to translate what the variable means.
 Explicit is better than implicit.
 
 **Bad:**
+
 ```python
 seq = ("Austin", "New York", "San Francisco")
 
@@ -184,6 +193,7 @@ for item in seq:
 ```
 
 **Good**:
+
 ```python
 locations = ("Austin", "New York", "San Francisco")
 
@@ -265,12 +275,14 @@ arguments then your function is trying to do too much. In cases where it's not, 
 of the time a higher-level object will suffice as an argument.
 
 **Bad:**
+
 ```python
 def create_menu(title, body, button_text, cancellable):
     pass
 ```
 
 **Java-esque**:
+
 ```python
 class Menu:
     def __init__(self, config: dict):
@@ -289,6 +301,7 @@ menu = Menu(
 ```
 
 **Also good**
+
 ```python
 from typing import Text
 
@@ -325,6 +338,7 @@ create_menu(config)
 ```
 
 **Fancy**
+
 ```python
 from typing import NamedTuple
 
@@ -359,6 +373,7 @@ create_menu(
 ```
 
 **Even fancier**
+
 ```python
 from typing import Text
 from dataclasses import astuple, dataclass
@@ -394,6 +409,7 @@ create_menu(
 ```
 
 **Even fancier, Python3.8+ only**
+
 ```python
 from typing import TypedDict, Text
 
@@ -438,6 +454,7 @@ cleaner. If you take nothing else away from this guide other than this, you'll b
 of many developers.
 
 **Bad:**
+
 ```python
 from typing import List
 
@@ -459,6 +476,7 @@ def email_clients(clients: List[Client]) -> None:
 ```
 
 **Good**:
+
 ```python
 from typing import List
 
@@ -487,6 +505,7 @@ def email_clients(clients: List[Client]) -> None:
 Do you see an opportunity for using generators now?
 
 **Even better**
+
 ```python
 from typing import Generator, Iterator
 
@@ -694,6 +713,7 @@ print(fullname)  # ["Ryan", "McDermott"]
 ```
 
 **Good:**
+
 ```python
 from typing import List, AnyStr
 
@@ -708,6 +728,7 @@ print(name, surname)  # => Ryan McDermott
 ```
 
 **Also good**
+
 ```python
 from typing import Text
 from dataclasses import dataclass


### PR DESCRIPTION
Some markdown editor, such as Working Copy on iPad, need a blank line before code block for correct rendering.